### PR TITLE
Fix handling header value conteaining non ASCII characters

### DIFF
--- a/request/builder/base.go
+++ b/request/builder/base.go
@@ -18,8 +18,10 @@ package builder
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -225,13 +227,25 @@ func (b *BaseBuilder) parseRequestURL() error {
 
 func (b *BaseBuilder) setupHeaders(httpRequest *http.Request) error {
 	if b.parsedHeaders != nil {
+
 		for headerKey, headerValue := range *b.parsedHeaders {
-			for _, r := range headerValue {
-				if r > unicode.MaxASCII {
-					headerValue = utils.URLQueryEscape(headerValue)
-					break
+			if headerKey == "X-QS-Fetch-Source" {
+				// header X-QS-Fetch-Source is a URL to fetch.
+				// We should first parse this URL.
+				requestURL, err := url.Parse(headerValue)
+				if err != nil {
+					return fmt.Errorf("invalid HTTP header value: %s", headerValue)
+				}
+				headerValue = requestURL.String()
+			} else {
+				for _, r := range headerValue {
+					if r > unicode.MaxASCII {
+						headerValue = utils.URLQueryEscape(headerValue)
+						break
+					}
 				}
 			}
+
 			httpRequest.Header.Set(headerKey, headerValue)
 		}
 	}


### PR DESCRIPTION
When handling header "X-QS-Fetch-Source",if there is some non ASCII
characters in header value, escape ASCII punctuation marks such like
"colon" will cause the encodeed header value to not work properly.

Fix handling header value conteaining non ASCII characters