### PR TITLE
update template to adjust addtion in API specs

### DIFF
--- a/service/bucket.go
+++ b/service/bucket.go
@@ -30,13 +30,13 @@ import (
 	"github.com/yunify/qingstor-sdk-go/v3/utils"
 )
 
-var _ utils.Conn
 var _ fmt.State
 var _ io.Reader
 var _ http.Header
 var _ strings.Reader
 var _ time.Time
 var _ config.Config
+var _ utils.Conn
 
 // Bucket presents bucket.
 type Bucket struct {

--- a/template/shared.tmpl
+++ b/template/shared.tmpl
@@ -19,7 +19,7 @@
     {{- else if eq $typeName "object" -}}
         interface{}
     {{- else if eq $typeName "map" -}}
-        interface{}
+        *map[string]string
     {{- else if eq $typeName "any" -}}
         interface{}
     {{- else -}}
@@ -35,7 +35,7 @@
         {{template "Type" passThrough $property.ExtraType $disablePointer}}
     {{- else if eq $property.Type "array" -}}
         []{{template "Type" passThrough $property.ExtraType $disablePointer}}
-    {{- else if eq $property.Type "map[string]string" -}}
+    {{- else if eq $property.Type "map" -}}
         *map[string]string 
     {{- else if eq $property.Type "any" -}}
         {{template "Type" passThrough $property.Type $disablePointer}}
@@ -359,7 +359,7 @@
                 {{end}}
             {{end}}
 
-            {{if eq $property.Type "map[string]string"}}
+            {{if eq $property.Type "map"}}
                 {{if eq $property.ID "X-QS-MetaData" }}
                     if v.XQSMetaData != nil {
 		                XQSMetaDataerr := utils.IsMetaDataValid(v.XQSMetaData)


### PR DESCRIPTION
API specs has changed metadata's type from map[string]string to map for adaptation of generating sdk by other languages. 
So the template also  changed.
`make generate`  has been execute to keep consistency between `template/*.tmpl` and `service/*.go` that auto-generated.

Signed-off-by: Ubique0305 <1071763478@qq.com>