### PR TITLE
fix: remove http retry logic to avoid body length 0 error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,10 +35,9 @@ type Config struct {
 	AccessKeyID     string `yaml:"access_key_id"`
 	SecretAccessKey string `yaml:"secret_access_key"`
 
-	Host              string `yaml:"host"`
-	Port              int    `yaml:"port"`
-	Protocol          string `yaml:"protocol"`
-	ConnectionRetries int    `yaml:"connection_retries"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	Protocol string `yaml:"protocol"`
 
 	AdditionalUserAgent string `yaml:"additional_user_agent"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,19 +25,17 @@ import (
 
 func TestConfig(t *testing.T) {
 	c := Config{
-		AccessKeyID:       "AccessKeyID",
-		SecretAccessKey:   "SecretAccessKey",
-		Host:              "qingstor.dev",
-		Port:              443,
-		Protocol:          "https",
-		ConnectionRetries: 10,
-		LogLevel:          "warn",
+		AccessKeyID:     "AccessKeyID",
+		SecretAccessKey: "SecretAccessKey",
+		Host:            "qingstor.dev",
+		Port:            443,
+		Protocol:        "https",
+		LogLevel:        "warn",
 	}
 
 	assert.Equal(t, "AccessKeyID", c.AccessKeyID)
 	assert.Equal(t, "SecretAccessKey", c.SecretAccessKey)
 	assert.Equal(t, "qingstor.dev", c.Host)
-	assert.Equal(t, 10, c.ConnectionRetries)
 	assert.Equal(t, "warn", c.LogLevel)
 
 	c.AdditionalUserAgent = `"`
@@ -94,7 +92,6 @@ func TestNewDefault(t *testing.T) {
 	assert.Equal(t, "", config.SecretAccessKey)
 	assert.Equal(t, "https", config.Protocol)
 	assert.Equal(t, "qingstor.com", config.Host)
-	assert.Equal(t, 3, config.ConnectionRetries)
 }
 
 func TestNew(t *testing.T) {

--- a/config/contract.go
+++ b/config/contract.go
@@ -33,7 +33,6 @@ const DefaultConfigFileContent = `# QingStor services configuration
 host: qingstor.com
 port: 443
 protocol: https
-connection_retries: 3
 
 # Additional User-Agent
 additional_user_agent: ""

--- a/request/request.go
+++ b/request/request.go
@@ -212,27 +212,15 @@ func (r *Request) send() error {
 		r.Operation.Config.InitHTTPClient()
 	}
 
-	retries := r.Operation.Config.ConnectionRetries + 1
-	for {
-		if retries > 0 {
-			logger.Infof(nil, fmt.Sprintf(
-				"Sending request: [%d] %s %s",
-				convert.StringToTimestamp(r.HTTPRequest.Header.Get("Date"), convert.RFC822),
-				r.Operation.RequestMethod,
-				r.HTTPRequest.Host,
-			))
+	logger.Infof(nil, fmt.Sprintf(
+		"Sending request: [%d] %s %s",
+		convert.StringToTimestamp(r.HTTPRequest.Header.Get("Date"), convert.RFC822),
+		r.Operation.RequestMethod,
+		r.HTTPRequest.Host,
+	))
 
-			response, err = r.Operation.Config.Connection.Do(r.HTTPRequest)
-			if err == nil {
-				retries = 0
-			} else {
-				retries--
-				time.Sleep(time.Second)
-			}
-		} else {
-			break
-		}
-	}
+	response, err = r.Operation.Config.Connection.Do(r.HTTPRequest)
+
 	if err != nil {
 		return err
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -220,7 +220,6 @@ func (r *Request) send() error {
 	))
 
 	response, err = r.Operation.Config.Connection.Do(r.HTTPRequest)
-
 	if err != nil {
 		return err
 	}

--- a/test/config.yaml.example
+++ b/test/config.yaml.example
@@ -6,7 +6,6 @@ secret_access_key: SECRET_ACCESS_KEY
 host: qingstor.com
 port: 443
 protocol: https
-connection_retries: 3
 
 # Additional User-Agent
 additional_user_agent: "test/integration"


### PR DESCRIPTION
This PR is to resolve  body length 0 error problem in issue #71 , follow the Steps 
> remove the http retry logic

it can avoid the error caused by `http.Client.Do()` in loop without recreation. 

By the way, for `testConfig` in `main_test.go`,I think it will not cause error in #71 because the  http request is rebuilt in every retry.So I didn't remove them.
Signed-off-by: Ubique0305 <1071763478@qq.com>