### PR TITLE
automatically switch to normal upload while fileSize < smallest Partsize

### DIFF
--- a/client/upload/upload_client.go
+++ b/client/upload/upload_client.go
@@ -137,7 +137,7 @@ func getFileSize(fd io.Reader) (int64, error) {
 		length = n
 	}
 	if length == -1 {
-		return length,errors.New("The file is not seekable.")
+		return length, errors.New("The file is not seekable")
 	}
 	return length, nil
 }

--- a/client/upload/upload_client.go
+++ b/client/upload/upload_client.go
@@ -135,8 +135,6 @@ func getFileSize(fd io.Reader) (int64, error) {
 			return length, err
 		}
 		length = n
-
 	}
 	return length, nil
-
 }

--- a/client/upload/upload_client.go
+++ b/client/upload/upload_client.go
@@ -124,7 +124,7 @@ func (u *Uploader) complete(objectKey string, uploadID *string, partNumbers []*s
 }
 
 func getFileSize(fd io.Reader) (int64, error) {
-	var length int64
+	var length int64 = -1
 	switch r := fd.(type) {
 	case io.Seeker:
 		pos, _ := r.Seek(0, 1)
@@ -135,6 +135,9 @@ func getFileSize(fd io.Reader) (int64, error) {
 			return length, err
 		}
 		length = n
+	}
+	if length == -1 {
+		return length,errors.New("The file is not seekable.")
 	}
 	return length, nil
 }


### PR DESCRIPTION
Add feature of the first point in #51 , automatically switch to normal upload while fileSize < smallest part size.
The second point in #51 has been added in `initSize()` in `client/upload/chunk.go`,it adjust partSize if it is too small to the file size.

Signed-off-by: Ubique0305 <1071763478@qq.com>