### PR TITLE
Fix signed url invalid when non-ascii used

### DIFF
--- a/request/signer/qingstor.go
+++ b/request/signer/qingstor.go
@@ -212,10 +212,6 @@ func (qss *QingStorSigner) buildCanonicalizedResource(request *http.Request) (st
 			if len(values) > 0 {
 				if values[0] != "" {
 					value := strings.TrimSpace(strings.Join(values, ""))
-					value, err := utils.URLQueryUnescape(value)
-					if err != nil {
-						return "", err
-					}
 					parts = append(parts, key+"="+value)
 				} else {
 					parts = append(parts, key)


### PR DESCRIPTION
Failed with non-ascii character used.

Unescape should not be used in:
https://github.com/yunify/qingstor-sdk-go/blob/3cac05d2026657bda7a59de03fb4bc411c4554e4/request/signer/qingstor.go#L215

Cause gatekeeper will also calculate the signature in url-encoded mode.

But I still think if there is a better approach to implement our customized url encoding in go.
It will be more robust to use different escape strategy when it comes to different part of a url(like path, query params, and our custom http headers).

However, this approach can be accepted now cause case like '特殊?$&ab c=符号.jpg' through the tests and also cases only contains non-ctl ascii character.